### PR TITLE
Add graphite module into rocks manifest

### DIFF
--- a/manifest
+++ b/manifest
@@ -64,6 +64,13 @@ repository = {
          }
       }
    },
+   graphite = {
+      ["scm-1"] = {
+         {
+            arch = "rockspec"
+         }
+      }
+   },
    http = {
       ["scm-1"] = {
          {


### PR DESCRIPTION
There is rockspec file for [graphite](https://github.com/tarantool/graphite) module but no module found when doing `rocks search`:

```
$ tarantoolctl rocks search graphite 

Search results:
===============
```