### PR TITLE
ldecnumber scm-1 rockspec

### DIFF
--- a/ldecnumber-1.0.0-1.rockspec
+++ b/ldecnumber-1.0.0-1.rockspec
@@ -1,6 +1,6 @@
 package = 'ldecnumber'
 
-version = '1.0.0'
+version = '1.0.0-1'
 
 source  = {
     url = 'git://github.com/tarantool/ldecnumber.git';

--- a/ldecnumber-1.0.0.rockspec
+++ b/ldecnumber-1.0.0.rockspec
@@ -1,10 +1,10 @@
 package = 'ldecnumber'
 
-version = 'scm-1'
+version = '1.0.0'
 
 source  = {
-    url    = 'git://github.com/tarantool/ldecnumber.git';
-    branch = 'master';
+    url = 'git://github.com/tarantool/ldecnumber.git';
+    tag = '1.0.0';
 }
 
 description = {

--- a/ldecnumber-1.1.2-1.rockspec
+++ b/ldecnumber-1.1.2-1.rockspec
@@ -1,0 +1,45 @@
+package = 'ldecnumber'
+
+version = '1.1.2-1'
+
+source  = {
+    url = 'git://github.com/tarantool/ldecnumber.git';
+    tag = '1.1.2';
+}
+
+description = {
+    summary  = "Decimal Arithmetic package for Tarantool";
+    detailed = [[
+    The ldecNumber package implements the General Decimal
+    Arithmetic Specification. This specification defines
+    a decimal arithmetic which meets the requirements of
+    commercial, financial, and human-oriented applications.
+    It also matches the decimal arithmetic in the IEEE 754
+    Standard for Floating Point Arithmetic.
+    ]];
+    homepage = 'https://github.com/tarantool/ldecnumber';
+    maintainer = "Michael Filonenko <filonenko.mikhail@gmail.com>";
+    license  = 'ICU1.8.1';
+}
+
+dependencies = {
+    'tarantool';
+    'lua == 5.1';
+}
+
+external_dependencies = {
+    TARANTOOL = {
+        header = 'tarantool/module.h';
+    };
+}
+
+build = {
+    type = 'cmake';
+    variables = {
+        CMAKE_BUILD_TYPE="RelWithDebInfo";
+        TARANTOOL_DIR="$(TARANTOOL_DIR)";
+        TARANTOOL_INSTALL_LIBDIR="$(LIBDIR)";
+        TARANTOOL_INSTALL_LUADIR="$(LUADIR)";
+    };
+}
+-- vim: syntax=lua ts=4 sts=4 sw=4 et

--- a/ldecnumber-scm-1.rockspec
+++ b/ldecnumber-scm-1.rockspec
@@ -1,0 +1,39 @@
+package = 'ldecnumber'
+
+version = 'scm-1'
+
+source  = {
+    url    = 'git://github.com/tarantool/ldecnumber.git';
+    branch = 'master';
+}
+
+description = {
+    summary  = "Decimal Arithmetic package for Tarantool";
+    detailed = [[
+    The ldecNumber package implements the General Decimal Arithmetic Specification. This specification defines a decimal arithmetic which meets the requirements of commercial, financial, and human-oriented applications. It also matches the decimal arithmetic in the IEEE 754 Standard for Floating Point Arithmetic.
+    ]];
+    homepage = 'https://github.com/tarantool/ldecnumber.git';
+    maintainer = "Michael Filonenko <filonenko.mikhail@gmail.com>";
+    license  = 'BSD2';
+}
+
+dependencies = {
+    'lua == 5.1';
+}
+
+external_dependencies = {
+    TARANTOOL = {
+        header = 'tarantool/module.h';
+    };
+}
+
+build = {
+    type = 'cmake';
+    variables = {
+        CMAKE_BUILD_TYPE="RelWithDebInfo";
+        TARANTOOL_DIR="$(TARANTOOL_DIR)";
+        TARANTOOL_INSTALL_LIBDIR="$(LIBDIR)";
+        TARANTOOL_INSTALL_LUADIR="$(LUADIR)";
+    };
+}
+-- vim: syntax=lua ts=4 sts=4 sw=4 et

--- a/manifest
+++ b/manifest
@@ -173,6 +173,11 @@ repository = {
             arch = "rockspec"
          }
       },
+      ["1.1.2-1"] = {
+         {
+            arch = "rockspec"
+         }
+      },
       ["scm-1"] = {
          {
             arch = "rockspec"

--- a/manifest
+++ b/manifest
@@ -167,6 +167,13 @@ repository = {
          }
       }
    },
+   ldecnumber = {
+      ["scm-1"] = {
+         {
+            arch = "rockspec"
+         }
+      }
+   },
    ["lrexlib-pcre"] = {
       ["2.9.0-1"] = {
          {

--- a/manifest
+++ b/manifest
@@ -168,6 +168,11 @@ repository = {
       }
    },
    ldecnumber = {
+      ["1.0.0-1"] = {
+         {
+            arch = "rockspec"
+         }
+      },
       ["scm-1"] = {
          {
             arch = "rockspec"


### PR DESCRIPTION
ldecNumber -- a tarantool (luajit, Lua 5.1) wrapper for the decNumber Decimal Arithmetic package.

The wrapper and decNumber library are built as a monolithic Lua module.