### PR TITLE
Update tarantool-curl URL

### DIFF
--- a/tarantool-curl-2.3.1-1.rockspec
+++ b/tarantool-curl-2.3.1-1.rockspec
@@ -2,7 +2,7 @@ package = 'tarantool-curl'
 version = '2.3.1-1'
 
 source  = {
-    url = 'git://github.com/tarantool/curl.git';
+    url = 'git://github.com/tarantool/tarantool-curl.git';
     tag = '2.3.1';
 }
 
@@ -11,7 +11,7 @@ description = {
     detailed = [[
     This module is a set of bindings for libcurl that allows you to use most of standard HTTP client functions.
     ]];
-    homepage = 'https://github.com/tarantool/curl.git';
+    homepage = 'https://github.com/tarantool/tarantool-curl.git';
     license  = 'BSD';
     maintainer = "Konstantin Nazarov <racktear@tarantool.org>";
 }


### PR DESCRIPTION
It was changed because we forked curl/curl repository to tarantool/curl
to add it as a submodule. So tarantool/curl was moved to
tarantool/tarantool-curl.